### PR TITLE
Bugfix for thread fPtrs update in sync barrier during fast forward.

### DIFF
--- a/src/zsim.cpp
+++ b/src/zsim.cpp
@@ -509,10 +509,10 @@ uint32_t TakeBarrier(uint32_t tid, uint32_t cid) {
         info("Termination condition met, exiting");
         zinfo->sched->leave(procIdx, tid, newCid);
         SimEnd(); //need to call this on a per-process basis...
+    } else {
+        // Set fPtrs to those of the new core after possible context switch
+        fPtrs[tid] = cores[tid]->GetFuncPtrs();
     }
-
-    // Set fPtrs to those of the new core after possible context switch
-    fPtrs[tid] = cores[tid]->GetFuncPtrs();
 
     return newCid;
 }


### PR DESCRIPTION
Fix a bug in commit e2f1f7b8922f6defbea68c89821f76a597328267.

Sorry for my carelessness to miss the scenario for fast forward.