### PR TITLE
[build] Fix compatibility problem

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -17,10 +17,10 @@ def buildSim(cppFlags, dir, type, pgo=None):
     versionFile = joinpath(buildDir, "version.h")
     if os.path.exists(".git"):
         env.Command(versionFile, allSrcs + [".git/index", "SConstruct"],
-            'echo -e "#define ZSIM_BUILDDATE \\""`date`\\""\\\\n#define ZSIM_BUILDVERSION \\""`python misc/gitver.py`\\""" >>' + versionFile)
+            'printf "#define ZSIM_BUILDDATE \\"`date`\\"\\n#define ZSIM_BUILDVERSION \\"`python misc/gitver.py`\\"" >>' + versionFile)
     else:
         env.Command(versionFile, allSrcs + ["SConstruct"],
-            'echo -e "#define ZSIM_BUILDDATE \\""`date`\\""\\\\n#define ZSIM_BUILDVERSION \\""no git repo\\""" >>' + versionFile)
+            'printf "#define ZSIM_BUILDDATE \\"`date`\\"\\n#define ZSIM_BUILDVERSION \\"no git repo\\"" >>' + versionFile)
 
     # Parallel builds?
     #env.SetOption('num_jobs', 32)


### PR DESCRIPTION
'-e' option of `echo` is not a POSIX standard.
However, without `-e`, echo incurs following errors.

    build/opt/zsim_harness.cpp:316:5: error: stray ‘\’ in program
    build/opt/zsim_harness.cpp:316:5: error: stray ‘#’ in program
    build/opt/zsim_harness.cpp: In function ‘int main(int, char**)’:
    build/opt/zsim_harness.cpp:311:24: error: ‘ZSIM_BUILDVERSION’ was not declared in this scope
    build/opt/zsim_harness.cpp:316:5: error: expected ‘)’ before ‘n’
    build/opt/zsim_harness.cpp:316:5: error: ‘ZSIM_BUILDVERSION’ was not declared in this scope
    scons: *** [build/opt/zsim_harness.o] Error 1
    scons: building terminated because of errors.

With `-e`, echo can incur another problem.


    In file included from build/opt/zsim_harness.cpp:47:0:
    build/opt/version.h:1:4: error: stray ‘#’ in program
    -e #define ZSIM_BUILDDATE "Mon Aug 9 10:28:03 UTC 2015"
       ^
    build/opt/version.h:1:1: error: expected unqualified-id before ‘-’ token
    -e #define ZSIM_BUILDDATE "Mon Aug 9 10:28:03 UTC 2015"
    ^
    scons: *** [build/opt/zsim_harness.o] Error 1
    scons: building terminated because of errors.

`printf` can solve this compatibility problem.