### PR TITLE
Fix a non-integer sleep() call to an equivalent usleep() call.

### DIFF
--- a/src/zsim_harness.cpp
+++ b/src/zsim_harness.cpp
@@ -167,7 +167,7 @@ void sigHandler(int sig) {
             if (childInfo[i].status == PS_RUNNING) {
                 info("Killing process %d", cpid);
                 kill(-cpid, SIGKILL);
-                sleep(0.1);
+                usleep(100000);
                 kill(cpid, SIGKILL);
             }
         }


### PR DESCRIPTION
This allows the intended behavior and fulfills -Wliteral-conversion.