### PR TITLE
Add sim.outputDir to specify an alternative directory for zsim output files.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1012,6 +1012,7 @@ void SimInit(const char* configFile, const char* outputDir, uint32_t shmid) {
     config.get<uint32_t>("sim.gmMBytes", (1 << 10));
     if (!zinfo->attachDebugger) config.get<bool>("sim.deadlockDetection", true);
     config.get<bool>("sim.aslr", false);
+    config.get<const char*>("sim.outputDir", nullptr);
 
     //Write config out
     bool strictConfig = config.get<bool>("sim.strictConfig", true); //if true, panic on unused variables

--- a/src/zsim_harness.cpp
+++ b/src/zsim_harness.cpp
@@ -201,7 +201,7 @@ static time_t startTime;
 static time_t lastHeartbeatTime;
 static uint64_t lastCycles = 0;
 
-static void printHeartbeat(GlobSimInfo* zinfo) {
+static void printHeartbeat(GlobSimInfo* zinfo, const char* outputDir) {
     uint64_t cycles = zinfo->numPhases*zinfo->phaseLength;
     time_t curTime = time(nullptr);
     time_t elapsedSecs = curTime - startTime;
@@ -214,7 +214,9 @@ static void printHeartbeat(GlobSimInfo* zinfo) {
     char hostname[256];
     gethostname(hostname, 256);
 
-    std::ofstream hb("heartbeat");
+    std::string hbPath(outputDir);
+    hbPath += "/heartbeat";
+    std::ofstream hb(hbPath);
     hb << "Running on: " << hostname << std::endl;
     hb << "Start time: " << ctime_r(&startTime, time);
     hb << "Heartbeat time: " << ctime_r(&curTime, time);
@@ -323,9 +325,12 @@ int main(int argc, char *argv[]) {
 
     //Canonicalize paths --- because we change dirs, we deal in absolute paths
     const char* configFile = realpath(argv[1], nullptr);
-    const char* outputDir = getcwd(nullptr, 0); //already absolute
+    const char* cwd = getcwd(nullptr, 0); //already absolute
 
     Config conf(configFile);
+
+    //The output directory may be set in the config file
+    const char* outputDir = realpath(conf.get<const char*>("sim.outputDir", cwd), nullptr);
 
     if (atexit(exitHandler)) panic("Could not register exit handler");
 
@@ -416,7 +421,7 @@ int main(int argc, char *argv[]) {
             info("Attached to global heap");
         }
 
-        printHeartbeat(zinfo);  // ensure we dump hostname etc on early crashes
+        printHeartbeat(zinfo, outputDir);  // ensure we dump hostname etc on early crashes
 
         int left = sleep(sleepLength);
         int secsSlept = sleepLength - left;
@@ -448,7 +453,7 @@ int main(int argc, char *argv[]) {
             } //otherwise, activeProcs == 0; we're done
         }
 
-        printHeartbeat(zinfo);
+        printHeartbeat(zinfo, outputDir);
 
         //This solves a weird race in multiprocess where SIGCHLD does not always fire...
         int cpid = -1;


### PR DESCRIPTION
This change adds a config file option to choose the zsim output file directory:

`sim = {
    outputDir = "my/custom/directory/name";
};`

This essentially provides an alternative to changing the working directory before each test, and has the side benefit of documenting where the expected results are located. If this option is not specified, the current working directory is used as before.
