### PR TITLE
Added example config file modeling an Intel Xeon L5640

### DIFF
--- a/tests/ooo.cfg
+++ b/tests/ooo.cfg
@@ -1,0 +1,83 @@
+// zsim config file used for current OOO validation results
+// Models an Intel Xeon L5640
+
+sim = {
+    domains = 1;
+    phaseLength = 1000;
+    statsPhaseInterval = 10000;
+    gmMBytes = 8192;
+};
+
+sys = {
+    caches = {
+        l1d = {
+            array = {
+                type = "SetAssoc";
+                ways = 8;
+            };
+            caches = 6;
+            latency = 4;
+            size = 32768;
+        };
+        l1i = {
+            array = {
+                type = "SetAssoc";
+                ways = 4;
+            };
+            caches = 6;
+            latency = 3;
+            size = 32768;
+        };
+        l2 = {
+            array = {
+                type = "SetAssoc";
+                ways = 8;
+            };
+	    type = "Timing";
+	    mshrs = 10;
+            caches = 6;
+            latency = 7;
+            children = "l1i|l1d";
+            size = 262144;
+        };
+        l3 = {
+            array = {
+                hash = "H3";
+                type = "SetAssoc";
+                ways = 16;
+            };
+	    type = "Timing";
+	    mshrs = 16;
+            banks = 6;
+            caches = 1;
+            latency = 27;
+            children = "l2";
+            size = 12582912;
+        };
+    };
+
+    cores = {
+        westmere = {
+            cores = 6;
+            dcache = "l1d";
+            icache = "l1i";
+            type = "OOO";
+        };
+    };
+    
+    frequency = 2270;
+    lineSize = 64;
+    
+    mem = {
+        addrMapping = "rank:col:bank";
+        closedPage = True;
+        controllerLatency = 40;
+        controllers = 3;
+        tech = "DDR3-1333-CL10";
+        type = "DDR";
+    };
+};
+
+process0 = {
+    command = "ls";
+};


### PR DESCRIPTION
Currently, ZSim does not provide a reasonable config file modeling a detailed OOO CMP. I added one based on the configuration used in the original ZSim paper modeling an Intel Xeon L5640.