### PR TITLE
Support Ubuntu 22.04 + GCC-11.3 and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ External dependencies: `gcc >=4.6, pin, scons, libconfig, libhdf5, libelfg0`
 
 1. Clone a fresh copy of the git zsim repository (`git clone <path to zsim repo>`).
 
-2. Download Pin, http://www.pintool.org . Tested with Pin 2.8+ on an x86-64
+2. Download Pin 2.14 [here](https://software.intel.com/sites/landingpage/pintool/downloads/pin-2.14-71313-gcc.4.4.7-linux.tar.gz). Tested with Pin 2.8+ on an x86-64
    architecture. Compiler flags are set up for Pin 2.9 on x86-64. To get flags
    for other versions, examine the Pin makefile or derive from sample pintools.
    Set the PINPATH environment variable to Pin's base directory.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ External dependencies: `gcc >=4.6, pin, scons, libconfig, libhdf5, libelfg0`
       define the env var `LIBCONFIGPATH=<libconfig install path>`.
 
   3.2 libhdf5, http://www.hdfgroup.org (v1.8.4 path 1 or higher), and libelfg0.
-      The SConstruct file assumes these are installed in the system.
+      The SConstruct file assumes these are installed in the system. If you build
+      libhdf5 locally, set `HDF5PATH==<libhdf5 install path>`.
 
   3.3 (OPTIONAL) polarssl (currently used just for their SHA-1 hash function),
       http://www.polarssl.org Install locally as in 3.1 and define the env var
@@ -98,6 +99,12 @@ code with --p. These improve simulation performance with OOO cores by about
 NOTE: zsim uses C++11 features available in `gcc >=4.6` (such as range-based for
 loops, strictly typed enums, lambdas, and type inference). Older version of gcc
 will not work. zsim can also be built with `icc` (see the `SConstruct` file).
+gcc-5 upgrades the default ABI version and Pin is built with the older gcc-4.x ABI.
+When building zsim with `gcc>=5` (default in newer Linux versions, e.g. gcc-7.5 in
+Ubuntu 18.04), the above dependencies are recommended to be built with the older
+gcc-4.x ABI by adding the `-fabi-version=2 -D_GLIBCXX_USE_CXX11_ABI=0` compiler flags.
+The packages installed from `apt-get` are likely to be built with newer ABI, which
+may incur compatibility issues on newer Linux versions.
 
 **Using a virtual machine:** If you use another OS, can't make system-wide
 configuration changes, or just want to test zsim without modifying your system,
@@ -185,9 +192,9 @@ zsim. First, it needs to allow for large shared memory segments. Second, for
 Pin to work, it must allow a process to attach to any other from the user, not
 just to a child. Use sysctl to ensure that `kernel.shmmax=1073741824` (or larger)
 and `kernel.yama.ptrace_scope=0`. zsim has mainly been used in
-Ubuntu 11.10, 12.04, 12.10, 13.04, and 13.10, but it should work in other Linux
-distributions. Using it in OSs other than Linux (e.g,, OS X, Windows) will be
-non-trivial, since the user-level virtualization subsystem has deep ties into
+Ubuntu 11.10, 12.04, 12.10, 13.04, 13.10, 14.04, and 18.04, but it should work in
+other Linux distributions. Using it in OSs other than Linux (e.g,, OS X, Windows)
+will be non-trivial, since the user-level virtualization subsystem has deep ties into
 the Linux syscall interface.
 
 **Stats:** The simulator outputs periodic, eventual and end-of-sim stats files.

--- a/SConstruct
+++ b/SConstruct
@@ -8,7 +8,7 @@ def buildSim(cppFlags, dir, type, pgo=None):
     ''' Build the simulator with a specific base buid dir and config type'''
 
     buildDir = joinpath(dir, type)
-    print "Building " + type + " zsim at " + buildDir
+    print("Building " + type + " zsim at " + buildDir)
 
     env = Environment(ENV = os.environ, tools = ['default', 'textfile'])
     env["CPPFLAGS"] = cppFlags
@@ -37,7 +37,7 @@ def buildSim(cppFlags, dir, type, pgo=None):
     if "PINPATH" in os.environ:
         PINPATH = os.environ["PINPATH"]
     else:
-       print "ERROR: You need to define the $PINPATH environment variable with Pin's path"
+       print("ERROR: You need to define the $PINPATH environment variable with Pin's path")
        sys.exit(1)
 
     ROOT = Dir('.').abspath
@@ -46,7 +46,7 @@ def buildSim(cppFlags, dir, type, pgo=None):
     # NOTE (dsm 10 Jan 2013): Tested with Pin 2.10 thru 2.12 as well
     # NOTE: Original Pin flags included -fno-strict-aliasing, but zsim does not do type punning
     # NOTE (dsm 16 Apr 2015): Update flags code to support Pin 2.14 while retaining backwards compatibility
-    env["CPPFLAGS"] += " -g -std=c++0x -Wall -Wno-unknown-pragmas -Wno-deprecated -Wno-unused-function -fomit-frame-pointer -fno-stack-protector"
+    env["CPPFLAGS"] += " -g -std=c++0x -Wall -Wno-unknown-pragmas -Wno-deprecated -Wno-unused-function -Wno-catch-value -fomit-frame-pointer -fno-stack-protector"
     env["CPPFLAGS"] += " -MMD -DBIGARRAY_MULTIPLIER=1 -DUSING_XED -DTARGET_IA32E -DHOST_IA32E -fPIC -DTARGET_LINUX"
     # NOTE (yyf 17 Sep 2020): Enforce to use older ABI when compiled with gcc-5 or newer.
     env["CPPFLAGS"] += " -fabi-version=2 -D_GLIBCXX_USE_CXX11_ABI=0"
@@ -204,11 +204,11 @@ pgoPhase = GetOption('pgoPhase')
 # when you move the files. Check the repo for a version that tries this.
 if GetOption('pgoBuild'):
     for type in buildTypes:
-        print "Building PGO binary"
+        print("Building PGO binary")
         root = Dir('.').abspath
         testsDir = joinpath(root, "tests")
         trainCfgs = [f for f in os.listdir(testsDir) if f.startswith("pgo")]
-        print "Using training configs", trainCfgs
+        print("Using training configs", trainCfgs)
 
         baseDir = joinpath(baseBuildDir, "pgo-" + type)
         genCmd = "scons -j16 --pgoPhase=generate-" + type

--- a/SConstruct
+++ b/SConstruct
@@ -46,8 +46,10 @@ def buildSim(cppFlags, dir, type, pgo=None):
     # NOTE (dsm 10 Jan 2013): Tested with Pin 2.10 thru 2.12 as well
     # NOTE: Original Pin flags included -fno-strict-aliasing, but zsim does not do type punning
     # NOTE (dsm 16 Apr 2015): Update flags code to support Pin 2.14 while retaining backwards compatibility
-    env["CPPFLAGS"] += " -g -std=c++0x -Wall -Wno-unknown-pragmas -fomit-frame-pointer -fno-stack-protector"
+    env["CPPFLAGS"] += " -g -std=c++0x -Wall -Wno-unknown-pragmas -Wno-deprecated -Wno-unused-function -fomit-frame-pointer -fno-stack-protector"
     env["CPPFLAGS"] += " -MMD -DBIGARRAY_MULTIPLIER=1 -DUSING_XED -DTARGET_IA32E -DHOST_IA32E -fPIC -DTARGET_LINUX"
+    # NOTE (yyf 17 Sep 2020): Enforce to use older ABI when compiled with gcc-5 or newer.
+    env["CPPFLAGS"] += " -fabi-version=2 -D_GLIBCXX_USE_CXX11_ABI=0"
 
     # Pin 2.12+ kits have changed the layout of includes, detect whether we need
     # source/include/ or source/include/pin/
@@ -111,6 +113,7 @@ def buildSim(cppFlags, dir, type, pgo=None):
     env["LIBS"] = ["config++"]
 
     env["LINKFLAGS"] = ""
+    env["RPATH"] = []
 
     if useIcc:
         # icc libs
@@ -123,6 +126,11 @@ def buildSim(cppFlags, dir, type, pgo=None):
         env["LIBPATH"] += [joinpath(LIBCONFIGPATH, "lib")]
         env["CPPPATH"] += [joinpath(LIBCONFIGPATH, "include")]
 
+    if "HDF5PATH" in os.environ:
+        HDF5PATH = os.getenv("HDF5PATH")
+        env["CPPPATH"] += [joinpath(HDF5PATH, "include/")]
+        env["LIBPATH"] += [joinpath(HDF5PATH, "lib/")]
+        env["RPATH"]   += [joinpath(HDF5PATH, "lib/")]
 
     if "POLARSSLPATH" in os.environ:
         POLARSSLPATH = os.environ["POLARSSLPATH"]

--- a/misc/ffControl.py
+++ b/misc/ffControl.py
@@ -38,19 +38,19 @@ while matches < opts.maxMatches or opts.maxMatches <= 0:
     try:
         line = sys.stdin.readline()
     except:
-        print "stdin done, exiting"
+        print("stdin done, exiting")
         break
 
     if line.startswith("[H] Global segment shmid = "):
         targetShmid = int(line.split("=")[1].lstrip().rstrip())
-        print "Target shmid is", targetShmid
+        print("Target shmid is", targetShmid)
 
     if line.find(opts.lineMatch) >= 0:
         if targetShmid >= 0:
-            print "Match, calling fftoggle"
+            print("Match, calling fftoggle")
             matches += 1
             subprocess.call([os.path.join(opts.fftogglePath, "fftoggle"), str(targetShmid), str(opts.procIdx)])
         else:
-            print "Match but shmid is not valid, not sending signal (are you sure you specified procIdx correctly? it's not the PID)"
-print "Done, %d matches" % matches
+            print("Match but shmid is not valid, not sending signal (are you sure you specified procIdx correctly? it's not the PID)")
+print("Done, %d matches" % matches)
 

--- a/misc/gitver.py
+++ b/misc/gitver.py
@@ -11,4 +11,4 @@ shstat = dfstat.replace(" files changed", "fc").replace(" file changed", "fc") \
                .replace(" deletions(-)", "-").replace(" deletion(-)", "-") \
                .replace(",", "")
 diff = "clean" if len(dfstat) == 0 else shstat +  " " + dfhash
-print ":".join([branch, revnum, rshort, diff])
+print(":".join([branch, revnum, rshort, diff]))

--- a/misc/lint_includes.py
+++ b/misc/lint_includes.py
@@ -53,7 +53,7 @@ for src in srcs:
     f.close()
 
     bName = os.path.basename(src).split(".")[0]
-    print bName
+    print(bName)
 
     lines = [l for l in txt.split("\n")]
 
@@ -70,18 +70,18 @@ for src in srcs:
                 includeBlocks.append((blockStart, i))
                 blockStart = -1
 
-    print src, len(includeBlocks), "blocks"
+    print(src, len(includeBlocks), "blocks")
 
     newIncludes = [(s , e, sortIncludes(lines[s:e], bName)) for (s, e) in includeBlocks]
     for (s , e, ii) in newIncludes:
         # Print?
         if ii == lines[s:e]:
-            print "Block in lines %d-%d matches" % (s, e-1)
+            print("Block in lines %d-%d matches" % (s, e-1))
             continue
         for i in range(s, e):
-            print "%3d: %s%s | %s" % (i, lines[i], " "*(40 - len(lines[i][:39])), ii[i-s] if i-s < len(ii) else "")
-        print ""
-
+            print("%3d: %s%s | %s" % (i, lines[i], " "*(40 - len(lines[i][:39])), ii[i-s] if i-s < len(ii) else ""))
+        print("")
+    
     prevIdx = 0
     newLines = []
     for (s , e, ii) in newIncludes:
@@ -95,4 +95,4 @@ for src in srcs:
         f.write(outTxt)
         f.close()
 
-print "Done!"
+print("Done!")

--- a/misc/list_syscalls.py
+++ b/misc/list_syscalls.py
@@ -6,4 +6,4 @@ syscallDefs = os.popen(syscallCmd).read()
 sysList = [(int(numStr), name) for (name, numStr) in re.findall("#define __NR_(.*?) (\d+)", syscallDefs)]
 denseList = ["INVALID"]*(max([num for (num, name) in sysList]) + 1)
 for (num, name) in sysList: denseList[num] = name
-print '"' + '",\n"'.join(denseList) + '"'
+print('"' + '",\n"'.join(denseList) + '"')

--- a/src/core_recorder.cpp
+++ b/src/core_recorder.cpp
@@ -140,8 +140,10 @@ void CoreRecorder::recordAccess(uint64_t startCycle) {
         //tr.endEvent not linked to anything, it's a PUT
     }
 
-    origPrevResp->produceCrossings(&eventRecorder);
-    eventRecorder.getCrossingStack().clear();
+    if (zinfo->numDomains > 1) {
+        origPrevResp->produceCrossings(&eventRecorder);
+        eventRecorder.getCrossingStack().clear();
+    }
 }
 
 

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -72,6 +72,20 @@ Decoder::Instr::Instr(INS _ins) : ins(_ins), numLoads(0), numInRegs(0), numOutRe
             reg = REG_FullRegName(reg);  // eax -> rax, etc; o/w we'd miss a bunch of deps!
             if (read) inRegs[numInRegs++] = reg;
             if (write) outRegs[numOutRegs++] = reg;
+        } else if (INS_OperandIsAddressGenerator(ins, op)) {
+            // address generators occur in LEAs & satisfy neither IsMemory nor,
+            // more infuriatingly, IsReg. despite being one operand, address
+            // generators may introduce dependencies on up to two registers: the
+            // base and index registers
+            assert(INS_OperandReadOnly(ins, op));
+
+            // base register; optional
+            REG reg = INS_OperandMemoryBaseReg(ins, op);
+            if (REG_valid(reg)) inRegs[numInRegs++] = REG_FullRegName(reg);
+
+            // index register; optional
+            reg = INS_OperandMemoryIndexReg(ins, op);
+            if (REG_valid(reg)) inRegs[numInRegs++] = REG_FullRegName(reg);
         }
     }
 

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -86,6 +86,31 @@ Decoder::Instr::Instr(INS _ins) : ins(_ins), numLoads(0), numInRegs(0), numOutRe
             // index register; optional
             reg = INS_OperandMemoryIndexReg(ins, op);
             if (REG_valid(reg)) inRegs[numInRegs++] = REG_FullRegName(reg);
+        } else if (INS_OperandIsImmediate(ins, op)
+                   || INS_OperandIsBranchDisplacement(ins, op)) {
+            // No need to do anything for immediate operands
+        } else if (INS_OperandReg(ins, op) == REG_X87) {
+            // We don't model x87 accurately in general
+            //reportUnhandledCase(*this, "Instr");
+        } else {
+            assert(INS_OperandIsImplicit(ins, op));
+            // Pin classifies the use and update of RSP in various stack
+            // operations as "implicit" operands. Although they contribute to
+            // OperandCount, OperandIsReg surprisingly returns false.
+            // Let's not bother to add RSP to inRegs or outRegs here,
+            // since we won't want to consider it as an ordinary register operand.
+            // (See handling of stack operations in Decoder::decodeInstr.)
+            //
+            // Even more weirdly, the use and update of RSI and RDI in MOVSB
+            // and similar string-handling instructions are considered
+            // implicit operands for which OperandIsReg returns false.
+            // Oh well, with ERMSB in Ivy Bridge and later,
+            // who knows what's the right way to model these things anyway?
+
+            // [victory] I wish these assertion weren't true, so we could
+            //           cleanly check what the implicit register operand is.
+            assert(!REG_valid(INS_OperandReg(ins, op)));
+            assert(!REG_valid(INS_OperandMemoryBaseReg(ins, op)));
         }
     }
 

--- a/src/ooo_core.cpp
+++ b/src/ooo_core.cpp
@@ -143,9 +143,12 @@ void OOOCore::store(Address addr) {
 
 // Predicated loads and stores call this function, gets recorded as a 0-cycle op.
 // Predication is rare enough that we don't need to model it perfectly to be accurate (i.e. the uops still execute, retire, etc), but this is needed for correctness.
-void OOOCore::predFalseMemOp() {
-    // I'm going to go out on a limb and assume just loads are predicated (this will not fail silently if it's a store)
+void OOOCore::predFalseLoad() {
     loadAddrs[loads++] = -1L;
+}
+
+void OOOCore::predFalseStore() {
+    storeAddrs[stores++] = -1L;
 }
 
 void OOOCore::branch(Address pc, bool taken, Address takenNpc, Address notTakenNpc) {
@@ -490,13 +493,13 @@ void OOOCore::StoreFunc(THREADID tid, ADDRINT addr) {static_cast<OOOCore*>(cores
 void OOOCore::PredLoadFunc(THREADID tid, ADDRINT addr, BOOL pred) {
     OOOCore* core = static_cast<OOOCore*>(cores[tid]);
     if (pred) core->load(addr);
-    else core->predFalseMemOp();
+    else core->predFalseLoad();
 }
 
 void OOOCore::PredStoreFunc(THREADID tid, ADDRINT addr, BOOL pred) {
     OOOCore* core = static_cast<OOOCore*>(cores[tid]);
     if (pred) core->store(addr);
-    else core->predFalseMemOp();
+    else core->predFalseStore();
 }
 
 void OOOCore::BblFunc(THREADID tid, ADDRINT bblAddr, BblInfo* bblInfo) {

--- a/src/ooo_core.h
+++ b/src/ooo_core.h
@@ -470,7 +470,8 @@ class OOOCore : public Core {
 
         // Predicated loads and stores call this function, gets recorded as a 0-cycle op.
         // Predication is rare enough that we don't need to model it perfectly to be accurate (i.e. the uops still execute, retire, etc), but this is needed for correctness.
-        inline void predFalseMemOp();
+        inline void predFalseLoad();
+        inline void predFalseStore();
 
         inline void branch(Address pc, bool taken, Address takenNpc, Address notTakenNpc);
 

--- a/src/ooo_core_recorder.cpp
+++ b/src/ooo_core_recorder.cpp
@@ -268,8 +268,10 @@ void OOOCoreRecorder::recordAccess(uint64_t curCycle, uint64_t dispatchCycle, ui
     }
 
     // For multi-domain
-    lastEvProduced->produceCrossings(&eventRecorder);
-    eventRecorder.getCrossingStack().clear();
+    if (zinfo->numDomains > 1) {
+        lastEvProduced->produceCrossings(&eventRecorder);
+        eventRecorder.getCrossingStack().clear();
+    }
 }
 
 

--- a/src/pin_cmd.cpp
+++ b/src/pin_cmd.cpp
@@ -66,6 +66,7 @@ PinCmd::PinCmd(Config* conf, const char* configFile, const char* outputDir, uint
     wordfree(&p);
 
     //Load tool
+    args.push_back("-ifeellucky"); //bypass kernel version check
     args.push_back("-t");
     args.push_back(zsimPath);
 

--- a/src/profile_stats.h
+++ b/src/profile_stats.h
@@ -91,6 +91,8 @@ class TimeBreakdownStat : public VectorCounter {
         //I need to define this even though it is completely unnecessary, but only if I override init. gcc bug or C++ oddity?
         virtual void init(const char* name, const char* desc, uint32_t size, const char** names) {
             VectorCounter::init(name, desc, size, names); //will call our init(name, desc, size)
+            curState = 0;
+            startNs = getNs();
         }
 
         void transition(uint32_t newState) {

--- a/src/profile_stats.h
+++ b/src/profile_stats.h
@@ -58,7 +58,7 @@ class ClockStat : public ScalarStat {
         void end() {
             assert(startNs);
             uint64_t endNs = getNs();
-            assert(endNs >= startNs)
+            assert(endNs >= startNs);
             totalNs += (endNs - startNs);
             startNs = 0;
         }

--- a/src/signum.h
+++ b/src/signum.h
@@ -1,0 +1,58 @@
+/* Signal number definitions.  Linux version.
+   Copyright (C) 1995-2018 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#ifndef _BITS_SIGNUM_H
+#define _BITS_SIGNUM_H 1
+
+#ifndef _SIGNAL_H
+#error "Never include <bits/signum.h> directly; use <signal.h> instead."
+#endif
+
+#include <bits/signum-generic.h>
+
+/* Adjustments and additions to the signal number constants for
+   most Linux systems.  */
+
+#define	SIGSTKFLT	16	/* Stack fault (obsolete).  */
+#define	SIGPWR		30	/* Power failure imminent.  */
+
+#undef	SIGBUS
+#define	SIGBUS		 7
+#undef	SIGUSR1
+#define	SIGUSR1		10
+#undef	SIGUSR2
+#define	SIGUSR2		12
+#undef	SIGCHLD
+#define	SIGCHLD		17
+#undef	SIGCONT
+#define	SIGCONT		18
+#undef	SIGSTOP
+#define	SIGSTOP		19
+#undef	SIGTSTP
+#define	SIGTSTP		20
+#undef	SIGURG
+#define	SIGURG		23
+#undef	SIGPOLL
+#define	SIGPOLL		29
+#undef	SIGSYS
+#define SIGSYS		31
+
+#undef	__SIGRTMAX
+#define __SIGRTMAX	64
+
+#endif	/* <signal.h> included.  */

--- a/src/slab_alloc.h
+++ b/src/slab_alloc.h
@@ -111,7 +111,7 @@ class SlabAlloc {
                 ptr = curSlab->alloc(sz);
                 assert(ptr);
             }
-            assert((((uintptr_t)ptr) & SLAB_MASK) == (uintptr_t)curSlab)
+            assert((((uintptr_t)ptr) & SLAB_MASK) == (uintptr_t)curSlab);
             return ptr;
         }
 

--- a/src/virt/time.cpp
+++ b/src/virt/time.cpp
@@ -197,7 +197,7 @@ PostPatchFn PatchNanosleep(PrePatchArgs args) {
     // Check preconditions
     // FIXME, shouldn't this use safeCopy??
     if (!ts) return NullPostPatch;  // kernel will return EFAULT
-    if (ts->tv_sec < 0 || ts->tv_nsec < 0 || ts->tv_nsec > 999999999) return false;  // kernel will return EINVAL
+    if (ts->tv_sec < 0 || ts->tv_nsec < 0 || ts->tv_nsec > 999999999) return nullptr;  // kernel will return EINVAL
 
     uint64_t waitNsec = timespecToNs(*ts);
     if (waitNsec >= offsetNsec) waitNsec -= offsetNsec;

--- a/src/zsim.cpp
+++ b/src/zsim.cpp
@@ -28,7 +28,9 @@
 
 #include "zsim.h"
 #include <algorithm>
+#define _SIGNAL_H
 #include <bits/signum.h>
+#undef _SIGNAL_H
 #include <dlfcn.h>
 #include <execinfo.h>
 #include <fstream>

--- a/src/zsim.cpp
+++ b/src/zsim.cpp
@@ -29,7 +29,7 @@
 #include "zsim.h"
 #include <algorithm>
 #define _SIGNAL_H
-#include <bits/signum.h>
+#include <signum.h>
 #undef _SIGNAL_H
 #include <dlfcn.h>
 #include <execinfo.h>


### PR DESCRIPTION
1. Make zsim Ubuntu 18.04 + GCC-7.5 compatible.
2. Fix #192.
3. Minor fixes on missing semicolons.
4. Fix improper initialization of class TimeBreakdownStat.
5. Add a more robust implementation of the `assert` macro.
6. Improve simulation speed with single domain.
7. Fix untracked register dependencies for LEA instructions.
8. sconstruct is python3 compatible
9. skip arch_prctl syscall to make zsim ubuntu 20.04 and 22.04 compatible #261 
10. copy signum.h from 18.04 to the repo (since it is no longer offered in the newer version of glibc)
